### PR TITLE
Add looping over the domains

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -1,0 +1,1 @@
+example.com www.example.com

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -22,54 +22,57 @@ if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/
   echo
 fi
 
-echo "### Creating dummy certificate for $domains ..."
-path="/etc/letsencrypt/live/$domains"
-mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
-  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
-    -keyout '$path/privkey.pem' \
-    -out '$path/fullchain.pem' \
-    -subj '/CN=localhost'" certbot
-echo
-
+for domain in `cat domains.txt`; do
+    echo "### Creating dummy certificate for $domain ..."
+    path="/etc/letsencrypt/live/$domain"
+    mkdir -p "$data_path/conf/live/$domain"
+    docker-compose run --rm --entrypoint "\
+    openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+        -keyout '$path/privkey.pem' \
+        -out '$path/fullchain.pem' \
+        -subj '/CN=localhost'" certbot
+    echo
+done
 
 echo "### Starting nginx ..."
 docker-compose up --force-recreate -d nginx
 echo
 
-echo "### Deleting dummy certificate for $domains ..."
-docker-compose run --rm --entrypoint "\
-  rm -Rf /etc/letsencrypt/live/$domains && \
-  rm -Rf /etc/letsencrypt/archive/$domains && \
-  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
-echo
+for domain in `cat domains.txt`; do
+    echo "### Deleting dummy certificate for $domain ..."
+    docker-compose run --rm --entrypoint "\
+    rm -Rf /etc/letsencrypt/live/$domain && \
+    rm -Rf /etc/letsencrypt/archive/$domain && \
+    rm -Rf /etc/letsencrypt/renewal/$domain.conf" certbot
+    echo
 
 
-echo "### Requesting Let's Encrypt certificate for $domains ..."
-#Join $domains to -d args
-domain_args=""
-for domain in "${domains[@]}"; do
-  domain_args="$domain_args -d $domain"
+    echo "### Requesting Let's Encrypt certificate for $domain ..."
+    #Join $domains to -d args
+    domain_args=""
+    #for domain in "${domains[@]}"; do
+    #    domain_args="$domain_args -d $domain"
+    #done
+    domain_args="$domain_args -d $domain"
+
+    # Select appropriate email arg
+    case "$email" in
+    "") email_arg="--register-unsafely-without-email" ;;
+    *) email_arg="--email $email" ;;
+    esac
+
+    # Enable staging mode if needed
+    if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+    docker-compose run --rm --entrypoint "\
+    certbot certonly --webroot -w /var/www/certbot \
+        $staging_arg \
+        $email_arg \
+        $domain_args \
+        --rsa-key-size $rsa_key_size \
+        --agree-tos \
+        --force-renewal" certbot
+    echo
 done
-
-# Select appropriate email arg
-case "$email" in
-  "") email_arg="--register-unsafely-without-email" ;;
-  *) email_arg="--email $email" ;;
-esac
-
-# Enable staging mode if needed
-if [ $staging != "0" ]; then staging_arg="--staging"; fi
-
-docker-compose run --rm --entrypoint "\
-  certbot certonly --webroot -w /var/www/certbot \
-    $staging_arg \
-    $email_arg \
-    $domain_args \
-    --rsa-key-size $rsa_key_size \
-    --agree-tos \
-    --force-renewal" certbot
-echo
-
 echo "### Reloading nginx ..."
 docker-compose exec nginx nginx -s reload


### PR DESCRIPTION
Simple change to the init script. It now reads from a domains.txt file and for each line in the file it will create the dummy certificates, then it starts up nginx, and then loops over the domains.txt file once again and requests a new certificate.

Tested for a server I have that needed to have multiple domains so hopefully it works in general. 

The idea was taken from the code in Issue #6 but instead of taking from parameters it reads from the domains.txt file.