### PR TITLE
Add parameter --no-deps.

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -34,7 +34,7 @@ echo
 
 
 echo "### Starting nginx ..."
-docker-compose up --force-recreate -d nginx
+docker-compose up --force-recreate -d --no-deps nginx
 echo
 
 echo "### Deleting dummy certificate for $domains ..."


### PR DESCRIPTION
Edited the file init-letsencrypt.sh. Added parameter --no-deps in step 'Starting nginx', with purpose to don't recreat the linked containers.