### PR TITLE
Use `example.org` everywhere for consistency

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -5,7 +5,7 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-domains=(example.com www.example.com)
+domains=(example.org www.example.org)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="" # Adding a valid address is strongly recommended


### PR DESCRIPTION
This makes it a bit easier when doing a string search/replacement, by only having to replace `example.org`. Nginx's `app.conf` uses `example.org`.