### PR TITLE
Building the certbot image instead of pulling it.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,10 @@ services:
       - "443:443"
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
   certbot:
-    image: certbot/certbot
+    image: certbot/certbot:v0.36.0
+    context: 'https://github.com/certbot-docker/certbot-docker.git#v0.36.0:core'
+    args:
+      - CERTBOT_VERSION=0.36.0
     restart: unless-stopped
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt


### PR DESCRIPTION
Resolves issue on Raspberry Pi 3, where pulled certbot/certbot is not compatible.

Do not know how to not build it for non-rpi users though. Maybe this could be only in the main README file?