### PR TITLE
move domain name and proxy url to .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /data/certbot
+/data/nginx/app.conf
+.env

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > This repository is accompanied by a [step-by-step guide on how to
 set up nginx and Let’s Encrypt with Docker](https://medium.com/@pentacent/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71).
 
-`init-letsencrypt.sh` fetches and ensures the renewal of a Let’s
+`init.sh` first generate `app.conf` for nginx, with the domain name and proxy server from the environment variables file. It then fetches and ensures the renewal of a Let’s
 Encrypt certificate for one or multiple domains in a docker-compose
 setup with nginx.
 This is useful when you need to set up nginx as a reverse proxy for an
@@ -15,14 +15,19 @@ application.
 2. Clone this repository: `git clone https://github.com/wmnnd/nginx-certbot.git .`
 
 3. Modify configuration:
-- Add domains and email addresses to init-letsencrypt.sh
-- Replace all occurrences of example.org with primary domain (the first one you added to init-letsencrypt.sh) in data/nginx/app.conf
 
-4. Run the init script:
+Create a file named .env in the repository root. Place your domain name and url of the proxy server in the .env file.
 
-        ./init-letsencrypt.sh
+```
+DOMAIN_NAME=<YOUR_DOMAIN_NAME eg: example.com>
+SERVER_URL=<PROXY_URL eg: http://localhost:8000>
+```
 
-5. Run the server:
+4.  Run the init script:
+
+        ./init.sh
+
+5.  Run the server:
 
         docker-compose up
 

--- a/data/nginx/app.conf.template
+++ b/data/nginx/app.conf.template
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name example.org;
+    server_name $DOMAIN_NAME;
     server_tokens off;
 
     location /.well-known/acme-challenge/ {
@@ -14,16 +14,16 @@ server {
 
 server {
     listen 443 ssl;
-    server_name example.org;
+    server_name $DOMAIN_NAME;
     server_tokens off;
 
-    ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/$DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$DOMAIN_NAME/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     location / {
-        proxy_pass  http://example.org;
+        proxy_pass                              $SERVER_URL;
         proxy_set_header    Host                $http_host;
         proxy_set_header    X-Real-IP           $remote_addr;
         proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;

--- a/init.sh
+++ b/init.sh
@@ -5,7 +5,15 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-domains=(example.org www.example.org)
+# import env variables from .env
+set -a
+. ./.env
+set +a
+
+# create nginx config file from template
+sed -e 's+$DOMAIN_NAME+'$DOMAIN_NAME'+g' -e 's+$SERVER_URL+'$SERVER_URL'+g' ./data/nginx/app.conf.template > ./data/nginx/app.conf
+
+domains=($DOMAIN_NAME)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="" # Adding a valid address is strongly recommended


### PR DESCRIPTION
Move domain name and proxy URL to an environment variable file. So it can be modified easily in different environments such as testing server and production server.