### PR TITLE
Increase RSA key size for dummy certificate.

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -31,7 +31,7 @@ echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
 docker-compose run --rm --entrypoint "\
-  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+  openssl req -x509 -nodes -newkey rsa:2048 -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot


### PR DESCRIPTION
With the key size set to 1024, startup of the 'nginx' container fails on some systems (see error message below).  This results in what certbot suggests is a firewall issue, but is actually the lack of any container running to receive the authentication requests.

>nginx    | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
>nginx    | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
>nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
>nginx    | 10-listen-on-ipv6-by-default.sh: IPv6 listen already enabled, exiting
>nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
>nginx    | /docker-entrypoint.sh: Configuration complete; ready for start up
>nginx   | [redacted timestamp] [emerg] 1#1: SSL_CTX_use_certificate("/etc/letsencrypt/live/[redacted].com/fullchain.pem") failed (SSL: error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small)
>nginx    | nginx: [emerg] SSL_CTX_use_certificate("/etc/letsencrypt/live/[redacted].com/fullchain.pem") failed (SSL: error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small)
>nginx exited with code 1