### PR TITLE
Fix fake cert key length

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -31,7 +31,7 @@ echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
 docker-compose run --rm --entrypoint "\
-  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot


### PR DESCRIPTION
This changes the key length for the fake certificate to match the key length of the real certificate. A 1024-bit key prevented nginx from booting up on my server because of a "key too short" error.