### PR TITLE
Increase RSA to 2048

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -31,7 +31,7 @@ echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
 docker-compose run --rm --entrypoint "\
-  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+  openssl req -x509 -nodes -newkey rsa:2048 -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot


### PR DESCRIPTION
Latest versions of openssl consider keys with a bit length of 1024 to be insecure. This script now causes the following error: "SSL: error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small" and prevents nginx from starting.