### PR TITLE
2048 bit dummy key instead of 1024

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -31,7 +31,7 @@ echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
 docker-compose run --rm --entrypoint "\
-  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+  openssl req -x509 -nodes -newkey rsa:2048 -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot


### PR DESCRIPTION
1024 bit key fails on newer nginx, preventing nginx from starting "key too small". Changed dummy key to 2048.