### PR TITLE
Replace "data_path" variable by executing actions inside container directly

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -7,11 +7,10 @@ fi
 
 domains=(example.org www.example.org)
 rsa_key_size=4096
-data_path="./data/certbot"
 email="" # Adding a valid address is strongly recommended
 staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
-if [ -d "$data_path" ]; then
+if `docker-compose run --rm --entrypoint "[ -d /var/www/certbot/conf/live/$domains ]" certbot 2>/dev/null`; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
     exit
@@ -19,17 +18,17 @@ if [ -d "$data_path" ]; then
 fi
 
 
-if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+if [ ! `docker-compose run --rm --entrypoint "[ -d /var/www/certbot/conf/options-ssl-nginx.conf ]" certbot 2>/dev/null` ] || [ ! `docker-compose run --rm --entrypoint "[ -d /var/www/certbot/conf/ssl-dhparams.pem ]" certbot 2>/dev/null` ]; then
   echo "### Downloading recommended TLS parameters ..."
-  mkdir -p "$data_path/conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  docker-compose run --rm --entrypoint "mkdir -p /var/www/certbot/conf" certbot
+  docker-compose run --rm --entrypoint "wget https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf -O /var/www/certbot/conf/options-ssl-nginx.conf" certbot
+  docker-compose run --rm --entrypoint "wget https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem -O /var/www/certbot/conf/ssl-dhparams.pem" certbot
   echo
 fi
 
 echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
-mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "mkdir -p $path" certbot
 docker-compose run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
     -keyout '$path/privkey.pem' \


### PR DESCRIPTION
At now we have a "data_path" variable, that used for make actions with files. But we already have those folder inside container mounted, so we can remove the "data_path" variable to make configuration more simple, and do all actions inside container directly.