### PR TITLE
Fix could not auto renew certbot because of nginx listen 443 is not apply challenge

### DIFF
--- a/data/nginx/app.conf
+++ b/data/nginx/app.conf
@@ -22,6 +22,10 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location / {
         proxy_pass  http://example.org;
         proxy_set_header    Host                $http_host;


### PR DESCRIPTION
I have the same issue with the below problem:
https://community.letsencrypt.org/t/the-certificate-authority-failed-to-download-the-temporary-challenge-files-created-by-certbot-connection-refused/159426/8

So, To fix this, which add Nginx property challenge in listen 443