### PR TITLE
Add check for correct certbot image (amd64/arm32/arm64)

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -11,6 +11,21 @@ data_path="./data/certbot"
 email="" # Adding a valid address is strongly recommended
 staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
+# check correct architecture
+if [ -f docker-compose.yml ]; then
+  arch="$(uname -m)"
+  if [[ "$arch" == "x86_64" ]]; then 
+    sed -i 's/image: certbot\/certbot.*$/image: certbot\/certbot:latest/g' docker-compose.yml
+  elif [[ $(echo -e "$arch" | grep -e "arm" -e "aarch") ]]; then
+    if [[ $(echo -e "$arch" | grep -e "armv8" -e "aarch64") ]]; then
+      sed -i 's/image: certbot\/certbot.*$/image: certbot\/certbot:arm64v8-latest/g' docker-compose.yml
+    else
+      sed -i 's/image: certbot\/certbot.*$/image: certbot\/certbot:arm32v6-latest/g' docker-compose.yml
+    fi
+  fi  
+fi  
+
+
 if [ -d "$data_path" ]; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then


### PR DESCRIPTION
Adds a check for current architecture so docker grabs the correct images accordingly. Since certbot only provides amd64, arm32 and arm64 docker images, only those checks are made. This will change certbot image in `docker-compose.yml` automatically:

- x86_64 (amd64): `certbot/certbot:latest`
- arm, armv7, etc. : `certbot/certbot:armv6-latest`
- aarch64, aarch64_be, armv8b, armv8l, etc.: `certbot/certbot:armv8-latest`

Resolves #109 and #87 