### PR TITLE
Updated for Docker Compose V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ application.
 5. Answer prompt questions in terminal
 - Domains, Email, Testing.
 
-5. Run the server:
+6. Run the server:
 
         docker compose up
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is useful when you need to set up nginx as a reverse proxy for an
 application.
 
 ## Installation
-1. [Install docker-compose](https://docs.docker.com/compose/install/#install-compose).
+1. [Install docker engine](https://docs.docker.com/engine/install/).
 
 2. Clone this repository: `git clone https://github.com/wmnnd/nginx-certbot.git .`
 
@@ -24,7 +24,7 @@ application.
 
 5. Run the server:
 
-        docker-compose up
+        docker compose up
 
 ## Got questions?
 Feel free to post questions in the comment section of the [accompanying guide](https://medium.com/@pentacent/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ application.
 2. Clone this repository: `git clone https://github.com/wmnnd/nginx-certbot.git .`
 
 3. Modify configuration:
-- Add domains and email addresses to init-letsencrypt.sh
-- Replace all occurrences of example.org with primary domain (the first one you added to init-letsencrypt.sh) in data/nginx/app.conf
+- Replace all occurrences of example.org with primary domain (the first one you will add to init-letsencrypt.sh) in data/nginx/app.conf
 
 4. Run the init script:
 
         ./init-letsencrypt.sh
+
+5. Answer prompt questions in terminal
+- Domains, Email, Testing.
 
 5. Run the server:
 

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo 'Error: docker-compose is not installed.' >&2
+if ! [ -x "$(command -v docker compose)" ]; then
+  echo 'Error: docker compose is not installed.' >&2
   exit 1
 fi
 
@@ -30,7 +30,7 @@ fi
 echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
+docker compose run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
@@ -39,11 +39,11 @@ echo
 
 
 echo "### Starting nginx ..."
-docker-compose up --force-recreate -d nginx
+docker compose up --force-recreate -d nginx
 echo
 
 echo "### Deleting dummy certificate for $domains ..."
-docker-compose run --rm --entrypoint "\
+docker compose run --rm --entrypoint "\
   rm -Rf /etc/letsencrypt/live/$domains && \
   rm -Rf /etc/letsencrypt/archive/$domains && \
   rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
@@ -66,7 +66,7 @@ esac
 # Enable staging mode if needed
 if [ $staging != "0" ]; then staging_arg="--staging"; fi
 
-docker-compose run --rm --entrypoint "\
+docker compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $staging_arg \
     $email_arg \
@@ -77,4 +77,4 @@ docker-compose run --rm --entrypoint "\
 echo
 
 echo "### Reloading nginx ..."
-docker-compose exec nginx nginx -s reload
+docker compose exec nginx nginx -s reload

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -11,6 +11,20 @@ data_path="./data/certbot"
 email="" # Adding a valid address is strongly recommended
 staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
+read -p "Enter Domains (with spaces between each domain): " domains
+read -p "Enter email (Adding a valid address is strongly recommended): " email
+read -p "Are you testing(y/N): " -n 1 -r
+
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+	echo
+    staging=1
+fi
+
+echo "Domains: $domains"
+echo "Email: $email"
+echo "Testing: $staging"
+
 if [ -d "$data_path" ]; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then


### PR DESCRIPTION
docker-compose is not found in Docker Compose V2. If developer wants to install it manually it causes much more problems. 

So,  I updated it for Docker Compose V2. I was doing it in the server when I installed this but not necessary anymore.